### PR TITLE
docs: fix the incorrect slack url

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -11,7 +11,7 @@ K8sGPT is a tool for scanning your kubernetes clusters, diagnosing and triaging 
 
 ## Community ##
 We invite you to join and participate in our community. Connect here:
-* Slack: https://k8sgpt.slack.com
+* Slack: [https://k8sgpt.slack.com](https://join.slack.com/t/k8sgpt/shared_invite/zt-1rwe5fpzq-VNtJK8DmYbbm~iWL1H34nw)
 * Twitter: https://twitter.com/k8sgpt
 * LinkedIn: https://www.linkedin.com/company/k8sgpt-ai/
 


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes [#376](https://github.com/k8sgpt-ai/k8sgpt/issues/376)

## 📑 Description
In [K8sgpt GitHub repository](https://github.com/k8sgpt-ai) The [.github/README.MD](https://github.com/k8sgpt-ai/.github/blob/main/profile/README.md) file, under the community section, the displayed Slack link is incorrect. It redirects new contributors to a page that insists on an `@k8sgpt.ai` email address instead, I have updated the URL with the appropriate Slack invite link

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

cc @AlexsJones 
